### PR TITLE
Resolve SSL errors from Adam's blog articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Clockwork - a clock process to replace cron [![Build Status](https://api.travis-
 ===========================================
 
 Cron is non-ideal for running scheduled application tasks, especially in an app
-deployed to multiple machines.  [More details.](http://adam.heroku.com/past/2010/4/13/rethinking_cron/)
+deployed to multiple machines.  [More details.](http://adam.herokuapp.com/past/2010/4/13/rethinking_cron/)
 
 Clockwork is a cron replacement.  It runs as a lightweight, long-running Ruby
 process which sits alongside your web processes (Mongrel/Thin) and your worker
@@ -69,8 +69,8 @@ to do the work.  It avoids locking by running as a single process, but this
 makes it impossible to parallelize.  For doing the work, you should be using a
 job queueing system, such as
 [Delayed Job](http://www.therailsway.com/2009/7/22/do-it-later-with-delayed-job),
-[Beanstalk/Stalker](http://adam.heroku.com/past/2010/4/24/beanstalk_a_simple_and_fast_queueing_backend/),
-[RabbitMQ/Minion](http://adam.heroku.com/past/2009/9/28/background_jobs_with_rabbitmq_and_minion/),
+[Beanstalk/Stalker](http://adam.herokuapp.com/past/2010/4/24/beanstalk_a_simple_and_fast_queueing_backend/),
+[RabbitMQ/Minion](http://adam.herokuapp.com/past/2009/9/28/background_jobs_with_rabbitmq_and_minion/),
 [Resque](http://github.com/blog/542-introducing-resque), or
 [Sidekiq](https://github.com/mperham/sidekiq).  This design allows a
 simple clock process with no locks, but also offers near infinite horizontal


### PR DESCRIPTION
The README links to Adam's blog are triggering `net::ERR_CERT_COMMON_NAME_INVALID` SSL certificate errors. The certificate expects a `herokuapp.com` domain instead of the current `heroku.com`. The links still work after the change.

![image](https://cloud.githubusercontent.com/assets/1012322/21776115/4138bdb4-d6dc-11e6-9fc2-004bd6e884ad.png)
