### PR TITLE
Selectively ignore model attributes

### DIFF
--- a/clockwork.gemspec
+++ b/clockwork.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "clockwork"
-  s.version = "2.0.0"
+  s.version = "2.0.1"
 
   s.authors = ["Adam Wiggins", "tomykaira"]
   s.license = 'MIT'

--- a/lib/clockwork/database_events/event_collection.rb
+++ b/lib/clockwork/database_events/event_collection.rb
@@ -14,7 +14,14 @@ module Clockwork
       def has_changed?(model)
         return true if event.nil?
 
-        event.model_attributes != model.attributes
+        ignored_attributes = model.ignored_attributes if model.respond_to?(:ignored_attributes)
+        ignored_attributes ||= []
+
+        model_attributes = model.attributes.select do |k, _|
+          not ignored_attributes.include?(k.to_sym)
+        end
+
+        event.model_attributes != model_attributes
       end
 
       def unregister

--- a/lib/clockwork/database_events/event_store.rb
+++ b/lib/clockwork/database_events/event_store.rb
@@ -112,15 +112,19 @@ module Clockwork
         options = {
           :from_database => true,
           :synchronizer => self,
+          :ignored_attributes => [],
         }
 
         options[:at] = at_strings_for(model) if model.respond_to?(:at)
         options[:if] = ->(time){ model.if?(time) } if model.respond_to?(:if?)
         options[:tz] = model.tz if model.respond_to?(:tz)
+        options[:ignored_attributes] = model.ignored_attributes if model.respond_to?(:ignored_attributes)
 
         # store the state of the model at time of registering so we can
         # easily compare and determine if state has changed later
-        options[:model_attributes] = model.attributes
+        options[:model_attributes] = model.attributes.select do |k, v|
+          not options[:ignored_attributes].include?(k.to_sym)
+        end
 
         options
       end


### PR DESCRIPTION
Clockwork compares all attributes of the model between runs to determine if the model has changed, and if it has, it runs the event if all other conditions are met.

However, in certain cases, you may want to store additional attributes in your model that you don't want to affect whether a database event is executed prior to its next interval.

This patch introduces a new attribute called `ignored_attributes`, that lets you specify which attributes to blacklist for comparison.