### PR TITLE
Added Windows compatibility by filtering SIGHUP

### DIFF
--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -66,7 +66,7 @@ module Clockwork
 
       sig_read, sig_write = IO.pipe
 
-      %w[INT TERM HUP].each do |sig|
+      (%w[INT TERM HUP] & Signal.list.keys).each do |sig|
         trap sig do
           sig_write.puts(sig)
         end


### PR DESCRIPTION
from the list of trapped signals. SIGHUP and other signals are not available in Windows
builds of Ruby. Trying to trap them results in an ArgumentError.