### PR TITLE
Add Skip First Run option

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,19 @@ Clockwork.every(1.day, 'run.me.in.new.thread', :thread => true)
 
 If a job is long-running or IO-intensive, this option helps keep the clock precise.
 
+### :skip_first_run
+
+Normally, a clockwork process that is defined to run in a specified period will run at startup.
+This is sometimes undesired behaviour, if the action being run relies on other processes booting which may be slower than clock.
+To avoid this problem, `:skip_first_run` can be used.
+
+```ruby
+Clockwork.every(5.minutes, 'myjob', :skip_first_run => true)
+```
+
+The above job will not run at initial boot, and instead run every 5 minutes after boot.
+
+
 Configuration
 -----------------------
 

--- a/lib/clockwork/event.rb
+++ b/lib/clockwork/event.rb
@@ -21,7 +21,10 @@ module Clockwork
 
     def run_now?(t)
       t = convert_timezone(t)
-      elapsed_ready(t) and (@at.nil? or @at.ready?(t)) and (@if.nil? or @if.call(t))
+      return false unless elapsed_ready?(t)
+      return false unless run_at?(t)
+      return false unless run_if?(t)
+      true
     end
 
     def thread?
@@ -57,8 +60,16 @@ module Clockwork
       @manager.handle_error e
     end
 
-    def elapsed_ready(t)
+    def elapsed_ready?(t)
       @last.nil? || (t - @last.to_i).to_i >= @period
+    end
+
+    def run_at?(t)
+      @at.nil? || @at.ready?(t)
+    end
+
+    def run_if?(t)
+      @if.nil? || @if.call(t)
     end
 
     def validate_if_option(if_option)

--- a/lib/clockwork/event.rb
+++ b/lib/clockwork/event.rb
@@ -8,11 +8,12 @@ module Clockwork
       @period = period
       @job = job
       @at = At.parse(options[:at])
-      @last = nil
       @block = block
       @if = options[:if]
       @thread = options.fetch(:thread, @manager.config[:thread])
       @timezone = options.fetch(:tz, @manager.config[:tz])
+      @skip_first_run = options[:skip_first_run]
+      @last = @skip_first_run ? convert_timezone(Time.now) : nil
     end
 
     def convert_timezone(t)

--- a/test/event_test.rb
+++ b/test/event_test.rb
@@ -34,4 +34,41 @@ describe Clockwork::Event do
       end
     end
   end
+
+  describe '#run_now?' do
+    before do
+      @manager = Class.new
+      @manager.stubs(:config).returns({})
+    end
+
+    describe 'event skip_first_run option set to true' do
+      it 'returns false on first attempt' do
+        event = Clockwork::Event.new(@manager, 1, nil, nil, :skip_first_run => true)
+        assert_equal false, event.run_now?(Time.now)
+      end
+
+      it 'returns true on subsequent attempts' do
+        event = Clockwork::Event.new(@manager, 1, nil, nil, :skip_first_run => true)
+        # first run
+        event.run_now?(Time.now)
+
+        # second run
+        assert_equal true, event.run_now?(Time.now + 1)
+      end
+    end
+
+    describe 'event skip_first_run option not set' do
+      it 'returns true on first attempt' do
+        event = Clockwork::Event.new(@manager, 1, nil, nil)
+        assert_equal true, event.run_now?(Time.now + 1)
+      end
+    end
+
+    describe 'event skip_first_run option set to false' do
+      it 'returns true on first attempt' do
+        event = Clockwork::Event.new(@manager, 1, nil, nil, :skip_first_run => false)
+        assert_equal true, event.run_now?(Time.now)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Working w/ clockwork on Heroku, we often want to delay the first run of some jobs on deploys. Usually things like metric collection, particularly those triggering alerts. If they are run at the moment of deploy, they return bad data.
We'd like to delay the first run of these alerts for a single cycle.
I'm putting this PR up, not sure how in demand this particular feature is, but I'm open to alternatives if this isn't the route the maintainer wants to go.