### PR TITLE
remove activesupport dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Run on every first day of month.
 Clockwork.every(1.day, 'myjob', :if => lambda { |t| t.day == 1 })
 ```
 
-The argument is an instance of `ActiveSupport::TimeWithZone` if the `:tz` option is set. Otherwise, it's an instance of `Time`.
+The argument is an instance of `Time`. If the `:tz` option is set, it has the given time zone. Otherwise, the time zone is the system time zone.
 
 This argument cannot be omitted.  Please use _ as placeholder if not needed.
 

--- a/clockwork.gemspec
+++ b/clockwork.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
 
   s.add_dependency(%q<tzinfo>)
-  s.add_dependency(%q<activesupport>)
 
   s.add_development_dependency "bundler", "~> 1.3"
   s.add_development_dependency "rake"
+  s.add_development_dependency "activesupport"
   s.add_development_dependency "daemons"
   s.add_development_dependency "minitest", "~> 5.8"
   s.add_development_dependency "mocha"

--- a/lib/clockwork.rb
+++ b/lib/clockwork.rb
@@ -1,5 +1,4 @@
 require 'logger'
-require 'active_support/time'
 
 require 'clockwork/at'
 require 'clockwork/event'

--- a/lib/clockwork.rb
+++ b/lib/clockwork.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'tzinfo'
 
 require 'clockwork/at'
 require 'clockwork/event'

--- a/lib/clockwork/event.rb
+++ b/lib/clockwork/event.rb
@@ -16,7 +16,7 @@ module Clockwork
     end
 
     def convert_timezone(t)
-      @timezone ? t.in_time_zone(@timezone) : t
+      @timezone ? t.getlocal(TZInfo::Timezone.get(@timezone).period_for_utc(t).utc_total_offset) : t
     end
 
     def run_now?(t)

--- a/test/at_test.rb
+++ b/test/at_test.rb
@@ -2,7 +2,6 @@ require File.expand_path('../../lib/clockwork', __FILE__)
 require "minitest/autorun"
 require 'mocha/setup'
 require 'time'
-require 'active_support/time'
 
 describe 'Clockwork::At' do
   def time_in_day(hour, minute)

--- a/test/samples/signal_test.rb
+++ b/test/samples/signal_test.rb
@@ -1,4 +1,5 @@
 require 'clockwork'
+require 'active_support/time'
 
 module Clockwork
   LOGFILE = File.expand_path('../../tmp/signal_test.log', __FILE__)


### PR DESCRIPTION
This removes the dependency on ActiveSupport. It won't affect any existing projects, but will be helpful to any non Rails projects which want to avoid adding ActiveSupport. (I'm in this situation myself, and prefer clockwork over similar tools)

Also, I had issues running the tests locally; changing `require 'mocha/setup'` to `require 'mocha'` and moving it above `require 'mini_test/autorun'`/`require 'test/unit'` seemed to fix it. Travis appears to be working fine though, so I didn't want to commit anything related to that.