### PR TITLE
added section about integration testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -563,7 +563,9 @@ For more details, you can run `clockworkd -h`.
 Integration Testing
 -------------------
 
-There is a third-party library called [clockwork-mocks](https://github.com/dpoetzsch/clockwork-mocks) that helps with running scheduled tasks during integration testing.
+You could take a look at:
+* [clockwork-mocks](https://github.com/dpoetzsch/clockwork-mocks) that helps with running scheduled tasks during integration testing.
+* [clockwork-test](https://github.com/kevin-j-m/clockwork-test) which ensures that tasks are triggered at the right time
 
 Issues and Pull requests
 ------------------------

--- a/README.md
+++ b/README.md
@@ -560,6 +560,11 @@ clockworkd -c YOUR_CLOCK.rb start
 
 For more details, you can run `clockworkd -h`.
 
+Integration Testing
+-------------------
+
+There is a third-party library called [clockwork-mocks](https://github.com/dpoetzsch/clockwork-mocks) that helps with running scheduled tasks during integration testing.
+
 Issues and Pull requests
 ------------------------
 


### PR DESCRIPTION
I like clockwork a lot. However, for our system, I felt the need to test it as a whole including scheduled jobs with clockwork.

So I created a small helper gem that provides a simple manual scheduler for clockwork which allows to do exactly that. Please check out the example section in the readme of the gem, it should make the use case clear.

Because I believe this could be of interest for other users of your gem I propose to add the possibility to you readme. What do you think?