### PR TITLE
add rescue to prevent hung up by exception

### DIFF
--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -160,7 +160,14 @@ module Clockwork
 
     private
     def events_to_run(t)
-      @events.select{ |event| event.run_now?(t) }
+      @events.select do |event|
+        begin
+          event.run_now?(t)
+        rescue => e
+          log_error(e)
+          false
+        end
+      end
     end
 
     def register(period, job, block, options)


### PR DESCRIPTION
When exception is raised in callback of `at:`, clockwork hungs up without any message.

E.g.

```ruby
module Clockwork
  handler {}

  every(1.minute, 'some job', at: ->(time) { raise 'some error' })
end
```

To prevend this, I added `rescue` (and logging) to `Manager#events_to_run`.
I hope this help.
