### PR TITLE
Enforce uniqueness of job names

### DIFF
--- a/lib/clockwork/database_events/manager.rb
+++ b/lib/clockwork/database_events/manager.rb
@@ -8,7 +8,7 @@ module Clockwork
         @events.delete(event)
       end
 
-      def register(period, job, block, options)
+      def register(period, job, block, options, _skip_duplicate_check = false)
         @events << if options[:from_database]
           synchronizer = options.fetch(:synchronizer)
           model_attributes = options.fetch(:model_attributes)

--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -1,7 +1,7 @@
 module Clockwork
   class Manager
     class NoHandlerDefined < RuntimeError; end
-    class DuplicateEventNames < RunTimeError; end
+    class DuplicateEventNames < RuntimeError; end
 
     attr_reader :config
 
@@ -55,7 +55,7 @@ module Clockwork
       end
 
       if job == "unnamed"
-        job += @incrementer
+        job += "_#{@incrementer}"
         @incrementer += 1
       end
 

--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -8,6 +8,7 @@ module Clockwork
     def initialize
       @events = []
       @event_names = []
+      @incrementer = 0
       @callbacks = {}
       @config = default_configuration
       @handler = nil
@@ -52,6 +53,12 @@ module Clockwork
         options = job
         job = "unnamed"
       end
+
+      if job == "unnamed"
+        job += @incrementer
+        @incrementer += 1
+      end
+
       if options[:at].respond_to?(:each)
         every_with_multiple_times(period, job, options, &block)
       else

--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -175,7 +175,7 @@ module Clockwork
     def register(period, job, block, options, skip_duplicate_check = false)
       event = Event.new(self, period, job, block || handler, options)
       if @event_names.include?(job)
-        raise DuplicateNameError unless skip_duplicate_check
+        raise(DuplicateEventNames, "#{job} is identical to another event") unless skip_duplicate_check
       end
       @event_names << job
       @events << event

--- a/test/database_events/synchronizer_test.rb
+++ b/test/database_events/synchronizer_test.rb
@@ -164,7 +164,7 @@ describe Clockwork::DatabaseEvents::Synchronizer do
       end
 
       describe "when #name is defined" do
-        it 'runs daily event with at from databse only once' do
+        it 'runs daily event with at from database only once' do
           DatabaseEventModel.create(:frequency => 1.day, :at => next_minute(@now).strftime('%H:%M'))
           setup_sync(model: DatabaseEventModel, :every => @sync_frequency, :events_run => @events_run)
 

--- a/test/manager_test.rb
+++ b/test/manager_test.rb
@@ -155,12 +155,28 @@ describe Clockwork::Manager do
 
   it "should accept unnamed job" do
     event = @manager.every(1.minute)
-    assert_equal 'unnamed', event.job
+    assert_equal 'unnamed_0', event.job
   end
 
   it "should accept options without job name" do
     event = @manager.every(1.minute, {})
-    assert_equal 'unnamed', event.job
+    assert_equal 'unnamed_0', event.job
+  end
+
+  it "should accept multiple unnamed jobs" do
+    event = @manager.every(1.minute)
+    event2 = @manager.every(2.minutes)
+
+    assert_equal "unnamed_0", event.job
+    assert_equal "unnamed_1", event2.job
+  end
+
+  it "should accept multiple options without job name" do
+    event = @manager.every(1.minute, {})
+    event2 = @manager.every(2.minute, {})
+
+    assert_equal "unnamed_0", event.job
+    assert_equal "unnamed_1", event2.job
   end
 
   describe ':at option' do

--- a/test/manager_test.rb
+++ b/test/manager_test.rb
@@ -80,6 +80,13 @@ describe Clockwork::Manager do
     end
   end
 
+  it "aborts when there are multiple jobs with the same name" do
+    assert_raises(Clockwork::Manager::DuplicateEventNames) do
+      @manager.every(1.minute, "jobx")
+      @manager.every(2.minutes, "jobx")
+    end
+  end
+
   it "general handler" do
     $set_me = 0
     @manager.handler { $set_me = 1 }


### PR DESCRIPTION
As was discussed briefly in PR #22 we should probably enforce uniqueness of jobs being passed to clockwork. Non-unique names could potentially cause confusion when debugging, and when the expectation is that the name is unique.

### NOTE
This does not change the behaviour of the DatabaseEvents, beyond *ignoring* the new flag being passed. I am admittedly not familiar enough w/ DatabaseEvents to say whether this is a desirable change or whether this works w/ the current implementation of DatabaseEvents. Help in that area would be greatly appreciated :)