### PR TITLE
Version 2.0.3

### DIFF
--- a/clockwork.gemspec
+++ b/clockwork.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name = "clockwork"
-  s.version = "2.0.2"
+  s.version = "2.0.3"
 
   s.authors = ["Adam Wiggins", "tomykaira"]
   s.license = 'MIT'


### PR DESCRIPTION
Several changes have been made since the last released version (2.0.2)

Mainly, the changes around selectively ignoring model attributes are a new feature that is not present in any released version yet.

Bumping to `2.0.3`

Changes since last version -

11f80a0 Merge branch 'oogali-selectively-ignore-model-attributes'
348beac Merge branch 'selectively-ignore-model-attributes' of https://github.com/oogali/clockwork into oogali-selectively-ignore-model-attributes
d7a7466 Updated documentation to reflect new option
4ca6a28 Added the ability to selectively ignore certain attributes when determining if model state has changed
f2570c5 explicitly require tzinfo
8dad9f3 allow 1.seconds in test
7418d24 remove activesupport dependency
1c8146a Add snippet to readme about 'skip_first_run'
424db67 Add functionality for 'skip_first_run' option
de21223 Tests around 'skip_first_run_option'
4cdcfb3 Minor clean up, make this function easier to read
bfa6998 Bugfix: Absolute path for clock file does not work in Windows
a22595a Merge branch 'master' into selectively-ignore-model-attributes
939f389 Correct Links
4d10c73 Updated documentation to reflect new option
8d611a7 Added the ability to selectively ignore certain attributes when determining if model state has changed

