### PR TITLE
Allow database events to set `skip_first_run`

### DIFF
--- a/lib/clockwork/database_events/event_store.rb
+++ b/lib/clockwork/database_events/event_store.rb
@@ -119,6 +119,7 @@ module Clockwork
         options[:if] = ->(time){ model.if?(time) } if model.respond_to?(:if?)
         options[:tz] = model.tz if model.respond_to?(:tz)
         options[:ignored_attributes] = model.ignored_attributes if model.respond_to?(:ignored_attributes)
+        options[:skip_first_run] = model.skip_first_run if model.respond_to?(:skip_first_run)
 
         # store the state of the model at time of registering so we can
         # easily compare and determine if state has changed later


### PR DESCRIPTION
This would be real handy to have merged 👍 Currently database events set with only a frequency (e.g. every 3600 seconds) get triggered every time the event is modified or the clock process restarts. With this PR, we could simply allow the db event model to pass the highly useful `:skip_first_run` attribute that you added!