### PR TITLE
Validate if proc arity (argument count) - must be 1

### DIFF
--- a/lib/clockwork/event.rb
+++ b/lib/clockwork/event.rb
@@ -74,8 +74,9 @@ module Clockwork
     end
 
     def validate_if_option(if_option)
-      if if_option && !if_option.respond_to?(:call)
-        raise ArgumentError.new(':if expects a callable object, but #{if_option} does not respond to call')
+      return unless if_option
+      unless if_option.respond_to?(:call) && if_option.arity == 1
+        raise ArgumentError.new(':if expects a callable object that accepts a single argument, but #{if_option} is not')
       end
     end
   end

--- a/test/manager_test.rb
+++ b/test/manager_test.rb
@@ -260,6 +260,12 @@ describe Clockwork::Manager do
         @manager.every(1.second, 'myjob', :if => true)
       end
     end
+
+    it ":if does not have an arity of 1 then raise ArgumentError" do
+      assert_raises(ArgumentError) do
+        @manager.every(1.second, 'myjob', :if => lambda {})
+      end
+    end
   end
 
   describe "max_threads" do


### PR DESCRIPTION
At the moment if an `:if` argument is supplied that has an arity other than one, clockwork will fail late when trying to run the event. This recently cost us a bit of time to troubleshoot.

It would be great to validate as much as possible at startup so clockwork fails fast and problems can be found sooner than when the event is configured to run.

Another approach would be to check the proc arity and only pass the argument if required.