### PR TITLE
add event that caused the error to the handle_error call

### DIFF
--- a/lib/clockwork/event.rb
+++ b/lib/clockwork/event.rb
@@ -58,7 +58,7 @@ module Clockwork
       @block.call(@job, @last)
     rescue => e
       @manager.log_error e
-      @manager.handle_error e
+      @manager.handle_error e, self
     end
 
     def elapsed_ready?(t)

--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -150,8 +150,8 @@ module Clockwork
       config[:logger].error(e)
     end
 
-    def handle_error(e)
-      error_handler.call(e) if error_handler
+    def handle_error(e, event)
+      error_handler.call(e, event) if error_handler
     end
 
     def log(msg)

--- a/test/manager_test.rb
+++ b/test/manager_test.rb
@@ -370,8 +370,10 @@ describe Clockwork::Manager do
   describe 'error_handler' do
     before do
       @errors = []
-      @manager.error_handler do |e|
+      @events = []
+      @manager.error_handler do |e, event|
         @errors << e
+        @events << event
       end
 
       # block error log
@@ -385,6 +387,11 @@ describe Clockwork::Manager do
     it 'registered error_handler handles error from event' do
       @manager.tick
       assert_equal ['it error'], @errors.map(&:message)
+    end
+
+    it 'registered error_handler gets event that caused the error' do
+      @manager.tick
+      assert_equal ['myjob'], @events.map(&:job)
     end
 
     it 'error is notified to logger and handler' do


### PR DESCRIPTION
I'd like to be able to use information about failing jobs inside the error handler, so that I can do things like logging the name of the job or setting up some extra context for my error tracking software.

This patch adds the event that triggered the error to the `handle_error` call, so that the error handler proc will have access to it.