### PR TITLE
Fix countless warnings with the test suite

### DIFF
--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -37,7 +37,7 @@ module Clockwork
 
     def error_handler(&block)
       @error_handler = block if block_given?
-      @error_handler
+      @error_handler if instance_variable_defined?("@error_handler")
     end
 
     def on(event, options={}, &block)

--- a/test/at_test.rb
+++ b/test/at_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../../lib/clockwork', __FILE__)
 require "minitest/autorun"
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'time'
 require 'active_support/time'
 

--- a/test/clockwork_test.rb
+++ b/test/clockwork_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../../lib/clockwork', __FILE__)
 require 'minitest/autorun'
-require 'mocha/setup'
+require 'mocha/minitest'
 
 describe Clockwork do
   before do

--- a/test/database_events/support/active_record_fake.rb
+++ b/test/database_events/support/active_record_fake.rb
@@ -28,8 +28,8 @@ module ActiveRecordFake
   end
 
   module ClassMethods
-    def create *args
-      new *args
+    def create(*args)
+      new(*args)
     end
     
     def delete_all

--- a/test/database_events/synchronizer_test.rb
+++ b/test/database_events/synchronizer_test.rb
@@ -1,5 +1,5 @@
 require "minitest/autorun"
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'time'
 require 'active_support/time'
 

--- a/test/database_events/test_helpers.rb
+++ b/test/database_events/test_helpers.rb
@@ -36,19 +36,35 @@ end
 
 class DatabaseEventModel
   include ActiveRecordFake
-  attr_accessor :name, :frequency, :at, :tz
+  attr_accessor :frequency, :at, :tz
 
   def name
-    @name || "#{self.class}:#{id}"
+    if instance_variable_defined?("@name")
+      @name
+    else
+      "#{self.class}:#{id}"
+    end
+  end
+
+  def name=(name)
+    @name = name
   end
 end
 
 class DatabaseEventModel2
   include ActiveRecordFake
-  attr_accessor :name, :frequency, :at, :tz
+  attr_accessor :frequency, :at, :tz
 
   def name
-    @name || "#{self.class}:#{id}"
+    if instance_variable_defined?("@name")
+      @name
+    else
+      "#{self.class}:#{id}"
+    end
+  end
+
+  def name=(name)
+    @name = name
   end
 end
 
@@ -59,10 +75,18 @@ end
 
 class DatabaseEventModelWithIf
   include ActiveRecordFake
-  attr_accessor :name, :frequency, :at, :tz, :if_state
+  attr_accessor :frequency, :at, :tz, :if_state
 
   def name
-    @name || "#{self.class}:#{id}"
+    if instance_variable_defined?("@name")
+      @name
+    else
+      "#{self.class}:#{id}"
+    end
+  end
+
+  def name=(name)
+    @name = name
   end
 
   def if?(time)

--- a/test/manager_test.rb
+++ b/test/manager_test.rb
@@ -1,6 +1,6 @@
 require File.expand_path('../../lib/clockwork', __FILE__)
 require "minitest/autorun"
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'time'
 require 'active_support/time'
 

--- a/test/signal_test.rb
+++ b/test/signal_test.rb
@@ -1,5 +1,5 @@
 require 'test/unit'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'fileutils'
 
 class SignalTest < Test::Unit::TestCase


### PR DESCRIPTION
While working on #63 I noticed the test suite was outputting many noisy warnings. These should be easy to resolve. This is [an example Travis build](https://travis-ci.org/github/Rykian/clockwork/jobs/663603954) from #63 where you can see all the current warnings. 

What we are essentially left with is a circular require warning that I don't know how to address:

```
/home/travis/build/Rykian/clockwork/lib/clockwork/database_events/synchronizer.rb:1: warning: /home/travis/build/Rykian/clockwork/lib/clockwork/database_events/synchronizer.rb:1: warning: loading in progress, circular require considered harmful - /home/travis/build/Rykian/clockwork/lib/clockwork/database_events.rb
```

At the moment though just going with what's here would be a great improvement on making the test output less noisy as far as warnings go. Thanks!