### PR TITLE
Add "require 'ostruct'" in "event_store_test"

### DIFF
--- a/test/database_events/event_store_test.rb
+++ b/test/database_events/event_store_test.rb
@@ -1,6 +1,7 @@
 require "minitest/autorun"
 require 'clockwork/database_events/event_store'
 require 'clockwork/database_events/event_collection'
+require 'ostruct'
 
 describe Clockwork::DatabaseEvents::EventStore do
 


### PR DESCRIPTION
I get the following error without this:

    $ bundle exec rake

    ...

    Clockwork::DatabaseEvents::EventStore::#register#test_0001_adds the event to the event group:
    NameError: uninitialized constant OpenStruct
        /Users/jordan/repos/clockwork/test/database_events/event_store_test.rb:15:in `block (3 levels) in <top (required)>'

I'm not sure why Travis CI doesn't seem to be exhibiting the same error.