### PR TITLE
Require active support

### DIFF
--- a/lib/clockwork.rb
+++ b/lib/clockwork.rb
@@ -1,4 +1,5 @@
 require 'logger'
+require 'active_support'
 require 'active_support/time'
 
 require 'clockwork/at'


### PR DESCRIPTION
Requiring clockwork is currently failing with `uninitialized constant ActiveSupport::XmlMini::IsolatedExecutionState (NameError)` when using Rails 7.0.0.rc1.

As per the  [Active Support documentation](https://guides.rubyonrails.org/active_support_core_extensions.html#stand-alone-active-support), you should first require Active Support itself, which does not load any component by default, and then require the component you wish to use. So that's what I'm doing here.

I started to add Active Support 7 to the test matrix, but that would require a minitest version that isn't compatible with rubysl-test-unit, which, in turn, doesn't seem to be maintained anymore.

You can easily reproduce the issue by installing the Rails 7 gem, starting an IRB shell, and requiring clockwork:

```
> irb
>> require "clockwork"
/Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/xml_mini.rb:184:in `current_thread_backend': uninitialized constant ActiveSupport::XmlMini::IsolatedExecutionState (NameError)
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/xml_mini.rb:103:in `backend='
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/xml_mini.rb:201:in `<module:ActiveSupport>'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/xml_mini.rb:11:in `<top (required)>'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/core_ext/array/conversions.rb:3:in `require'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/core_ext/array/conversions.rb:3:in `<top (required)>'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/duration.rb:3:in `require'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/duration.rb:3:in `<top (required)>'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/core_ext/time/calculations.rb:3:in `require'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/core_ext/time/calculations.rb:3:in `<top (required)>'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/core_ext/time.rb:4:in `require'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/core_ext/time.rb:4:in `<top (required)>'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/time.rb:12:in `require'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/activesupport-7.0.0.rc1/lib/active_support/time.rb:12:in `<top (required)>'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/clockwork-2.0.4/lib/clockwork.rb:2:in `require'
	from /Users/codechimp/.gem/ruby/3.0.2/gems/clockwork-2.0.4/lib/clockwork.rb:2:in `<top (required)>'
	from (irb):2:in `require'
	... 19 levels...
```