### PR TITLE
Accept wildcards when specifying day of week

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,9 +324,7 @@ You can specify the day of week to run:
 ```ruby
 every(1.week, 'myjob', :at => 'Monday 16:20')
 # This runs every Monday at 16:20
-```
 
-```ruby
 every(1.hour, 'myjob', :at => 'Monday **:**')
 # This runs every hour only on Mondays
 ```

--- a/README.md
+++ b/README.md
@@ -287,6 +287,9 @@ Event Parameters
     **:MM
     HH:**
     (Mon|mon|Monday|monday) HH:MM
+    (Mon|mon|Monday|monday) HH:**
+    (Mon|mon|Monday|monday) **:MM
+    (Mon|mon|Monday|monday) **:**
 
 #### Examples
 
@@ -320,6 +323,12 @@ You can specify the day of week to run:
 
 ```ruby
 every(1.week, 'myjob', :at => 'Monday 16:20')
+# This runs every Monday at 16:20
+```
+
+```ruby
+every(1.hour, 'myjob', :at => 'Monday **:**')
+# This runs every hour only on Mondays
 ```
 
 If another task is already running at the specified time, clockwork will skip execution of the task with the `:at` option.

--- a/lib/clockwork/at.rb
+++ b/lib/clockwork/at.rb
@@ -12,6 +12,12 @@ module Clockwork
     def self.parse(at)
       return unless at
       case at
+      when /\A([[:alpha:]]+)\s\*{1,2}:\*{1,2}\z/
+        if wday = WDAYS[$1]
+          new(NOT_SPECIFIED, NOT_SPECIFIED, wday)
+        else
+         raise FailedToParse, at
+        end
       when /\A([[:alpha:]]+)\s(.*)\z/
         if wday = WDAYS[$1]
           parsed_time = parse($2)


### PR DESCRIPTION
The idea is to support wildcards when setting a day of week.
Use cases for this is if you want to send an alert every hour only on weekdays. 
Examples:
- Mon \**:**
- Mon 15:**
- Mon **:15

This was resolved setting `NOT_SPECIFIED` in both `min` and `hour` when matching that case (`/\A([[:alpha:]]+)\s\*{1,2}:\*{1,2}\z/`).

I've also updated the README reflecting this change.