### PR TITLE
For events_to_run add error handler usage

### DIFF
--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -165,6 +165,7 @@ module Clockwork
           event.run_now?(t)
         rescue => e
           log_error(e)
+          handle_error(e)
           false
         end
       end


### PR DESCRIPTION
I noticed in v3 that #24 was included but it only logs the error when it should use the error handler as it should still fail loudly. This follows the same approach as the private `execute` method in the `Event` class which does both, logs and notifies (handles) the error.