### PR TITLE
Test: use recent Minitest style

### DIFF
--- a/test/manager_test.rb
+++ b/test/manager_test.rb
@@ -117,7 +117,7 @@ describe Clockwork::Manager do
     @manager.handler { raise 'boom' }
     @manager.every(1.minute, 'myjob')
 
-    mocked_logger = MiniTest::Mock.new
+    mocked_logger = Minitest::Mock.new
     mocked_logger.expect :error, true, [RuntimeError]
     @manager.configure { |c| c[:logger] = mocked_logger }
     @manager.tick(Time.now)


### PR DESCRIPTION
Current style has long been to use Minitest instead of MiniTest, and with minitest 5.19, MiniTest usage support is
hidden unless explicitly setting ENV["MT_COMPAT"].

https://github.com/minitest/minitest/commit/a2c6c18570f6f0a1bf6af70fe3b6d9599a13fdd6

Use Minitest instead of MiniTest .

Closes #84 .