### PR TITLE
Fix test failure due to wrong module name

### DIFF
--- a/test/manager_test.rb
+++ b/test/manager_test.rb
@@ -117,7 +117,7 @@ describe Clockwork::Manager do
     @manager.handler { raise 'boom' }
     @manager.every(1.minute, 'myjob')
 
-    mocked_logger = MiniTest::Mock.new
+    mocked_logger = Minitest::Mock.new
     mocked_logger.expect :error, true, [RuntimeError]
     @manager.configure { |c| c[:logger] = mocked_logger }
     @manager.tick(Time.now)


### PR DESCRIPTION
One test is consistently failing on `master`:

```
1) Error:
Clockwork::Manager#test_0012_exceptions are trapped and logged:
NameError: uninitialized constant MiniTest
Did you mean?  Minitest
    test/manager_test.rb:1[20](https://github.com/c960657/clockwork/actions/runs/10076662391/job/27857488923#step:4:21):in `block (2 levels) in <top (required)>'
```

Minitest was [renamed to Minitest](https://github.com/ruby/ruby/commit/7cda8222ca6fa109e531705579164f56f29f8068#diff-2a72d0121a0eb22e9f32a1ce654e5132391273007bf643b5ae68fbbc2800dea4) in v5. Ruby stdlib [previously carried](https://github.com/minitest/minitest/blob/master/lib/minitest/mock.rb) minitest v4.
