### PR TITLE
Remove unused base64, bigdecimal and ostruct dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,3 +6,4 @@ rails_version = ENV.fetch("ACTIVE_SUPPORT_VERSION", "7.0")
 
 gem "activesupport", "~> #{rails_version}"
 gem "minitest", "~> 5.0"
+gem "ostruct"

--- a/clockwork.gemspec
+++ b/clockwork.gemspec
@@ -19,9 +19,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency(%q<tzinfo>)
   s.add_dependency(%q<activesupport>)
-  s.add_dependency(%q<base64>)
-  s.add_dependency(%q<bigdecimal>)
-  s.add_dependency(%q<ostruct>)
 
   s.add_development_dependency "rake"
   s.add_development_dependency "daemons"


### PR DESCRIPTION
[These 3 dependencies were added in this commit](https://github.com/Rykian/clockwork/commit/4f0d4a7c0f00fe0f64306a2844326c62c1a56b31#diff-c9a7ef3318660ff5cc0c9a572754eede8729f9b464e163638ff6f0c5366458c3) but they are unnecessary since the gem has no `Base64`, `BigDecimal` or `OpenStruct` references in user facing code. Once removed, only `ostruct` outputs a warning but that dependency is only needed in the test suite. An app that has a clockwork dependency should NOT be pulling in any of these dependencies.