### PR TITLE
Update ACTIVE_SUPPORT_VERSION default to 8.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gemspec
 
-rails_version = ENV.fetch("ACTIVE_SUPPORT_VERSION", "7.0")
+rails_version = ENV.fetch("ACTIVE_SUPPORT_VERSION", "8.1")
 
 gem "activesupport", "~> #{rails_version}"
 gem "minitest", "~> 5.0"


### PR DESCRIPTION
Since the Gemfile.lock is not committed and just running `bundle install` it will install ActiveSupport v7.0 when it should install 8.1 now as the default.