### PR TITLE
Drop test-unit dependency with migrated test to minitest

### DIFF
--- a/clockwork.gemspec
+++ b/clockwork.gemspec
@@ -27,5 +27,4 @@ Gem::Specification.new do |s|
   s.add_development_dependency "daemons"
   s.add_development_dependency "minitest", "~> 5.8"
   s.add_development_dependency "mocha"
-  s.add_development_dependency "test-unit"
 end

--- a/test/signal_test.rb
+++ b/test/signal_test.rb
@@ -1,34 +1,32 @@
-require 'test/unit'
+require "minitest/autorun"
 require 'mocha/minitest'
 require 'fileutils'
 
-class SignalTest < Test::Unit::TestCase
-  CMD     = File.expand_path('../../bin/clockwork', __FILE__)
-  SAMPLE  = File.expand_path('../samples/signal_test.rb', __FILE__)
-  LOGFILE = File.expand_path('../tmp/signal_test.log', __FILE__)
-
-  setup do
-    FileUtils.mkdir_p(File.dirname(LOGFILE))
-    @pid = spawn(CMD, SAMPLE)
-    until File.exist?(LOGFILE)
+describe "SignalTest" do
+  before do
+    @command = File.expand_path('../../bin/clockwork', __FILE__)
+    @sample = File.expand_path('../samples/signal_test.rb', __FILE__)
+    @logfile = File.expand_path('../tmp/signal_test.log', __FILE__)
+    FileUtils.mkdir_p(File.dirname(@logfile))
+    @pid = spawn(@command, @sample)
+    until File.exist?(@logfile)
       sleep 0.1
     end
   end
 
-  teardown do
-    FileUtils.rm_r(File.dirname(LOGFILE))
+  after do
+    FileUtils.rm_r(File.dirname(@logfile))
   end
 
-  test 'should gracefully shutdown with SIGTERM' do
+  it 'should gracefully shutdown with SIGTERM' do
     Process.kill(:TERM, @pid)
     sleep 0.2
-    assert_equal 'done', File.read(LOGFILE)
+    assert_equal 'done', File.read(@logfile)
   end
 
-  test 'should forcely shutdown with SIGINT' do
+  it 'should forcely shutdown with SIGINT' do
     Process.kill(:INT, @pid)
     sleep 0.2
-    assert_equal 'start', File.read(LOGFILE)
+    assert_equal 'start', File.read(@logfile)
   end
 end
-


### PR DESCRIPTION
This was the only test case still written using the test-unit dependency so it was converted to minitest spec so the test-unit dependency can be safely removed.